### PR TITLE
Remove duplicate code

### DIFF
--- a/includes/extension/inc/section.php
+++ b/includes/extension/inc/section.php
@@ -424,18 +424,6 @@ class jl_section_overlay
                     'jl_ov_enable' => 'yes',
                     'background_overlay_background' => ['classic', 'gradient'],
                 ],
-                'device_args' => [
-                    Controls_Stack::RESPONSIVE_TABLET => [
-                        'selectors' => [
-                            $selector => 'height: {{SIZE}}{{UNIT}};',
-                        ],
-                    ],
-                    Controls_Stack::RESPONSIVE_MOBILE => [
-                        'selectors' => [
-                            $selector => 'height: {{SIZE}}{{UNIT}};',
-                        ],
-                    ],
-                ],
             ]
         );
 


### PR DESCRIPTION
The plugin is using deprecated consts - `Controls_Stack::RESPONSIVE_TABLET` and `Controls_Stack::RESPONSIVE_MOBILE`.

In addition, it looks like the code sets specific selectors for the tablet & mobile breakpoints. However, it's the same selector as the original selector, so it doesn't really change anything. Therefor, the entire `device_args` argument is not really needed.